### PR TITLE
makes the main logo text a link to the root page

### DIFF
--- a/client/components/landing-page.js
+++ b/client/components/landing-page.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Item, Header } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
-import { fetchTopSongs } from '../store';
+import { fetchTopSongs, clearSongs } from '../store';
 
 /**
  * COMPONENT
@@ -12,10 +12,14 @@ class LandingPage extends React.Component {
     if (this.props.fetchData) this.props.fetchData();
   }
 
-  componentWillReceiveProps(newProps) {
-    if (!this.props.fetchData && newProps.fetchData) {
-      newProps.fetchData();
-    }
+  // componentWillReceiveProps(newProps) {
+  //   if (!this.props.fetchData && newProps.fetchData) {
+  //     newProps.fetchData();
+  //   }
+  // }
+
+  componentWillUnmount() {
+    this.props.clearData();
   }
 
   render() {
@@ -65,6 +69,7 @@ const mapDispatch = (dispatch) => {
       // fetches the top 50 songs
       dispatch(fetchTopSongs(50));
     },
+    clearData: () => dispatch(clearSongs()),
   };
 };
 

--- a/client/components/main.js
+++ b/client/components/main.js
@@ -17,7 +17,7 @@ const Main = (props) => {
   return (
     <div>
       <Menu stackable >
-      <Menu.Item header>SOUNDCROWD</Menu.Item>
+      <Menu.Item header as={Link} to="/">SOUNDCROWD</Menu.Item>
         {
           isLoggedIn
             ? <Menu.Menu>

--- a/client/store/songs.js
+++ b/client/store/songs.js
@@ -6,6 +6,7 @@ import axios from 'axios'
 const GET_SONG = 'GET_SONG';
 const REMOVE_SONG = 'REMOVE_SONG';
 const GET_SOME_SONGS = 'GET_SOME_SONGS';
+const CLEAR_SONGS = 'CLEAR_SONGS';
 
 /**
  * INITIAL STATE
@@ -15,10 +16,10 @@ const defaultSongs = [];
 /**
  * ACTION CREATORS
  */
-const getSong = song => ({ type: GET_SONG, song });
-const removeSong = song => ({ type: REMOVE_SONG, song });
-const getSomeSongs = songs => ({ type: GET_SOME_SONGS, songs });
-
+export const getSong = song => ({ type: GET_SONG, song });
+export const removeSong = song => ({ type: REMOVE_SONG, song });
+export const getSomeSongs = songs => ({ type: GET_SOME_SONGS, songs });
+export const clearSongs = () => ({ type: CLEAR_SONGS });
 
 /**
  * THUNK CREATORS
@@ -62,6 +63,8 @@ export default function (state = defaultSongs, action) {
       return [].concat(action.songs, state);
     case REMOVE_SONG:
       return state.filter(song => song.id !== action.song.id);
+    case CLEAR_SONGS:
+      return defaultSongs;
     default:
       return state;
   }


### PR DESCRIPTION
Also fixes an issue with loading the landing page that only became apparent once the main logo issue was fixed. Basically, it reloaded all the song data on componentDidMount, but never cleared that data, so it had many copies of the same song in the store. Now the data is cleared on componentWillUnmount