### PR TITLE
fixes bug on component will unmount

### DIFF
--- a/client/DAW/components/Timeline.js
+++ b/client/DAW/components/Timeline.js
@@ -189,7 +189,8 @@ class Timeline extends React.Component {
     this.clipsRef.off();
     this.tracksRef.off();
     this.filesRef.off();
-    this.settingsRef.off();
+    this.tempoRef.off();
+    this.lengthRef.off();
   }
 
   playSound(buffer, startTime, playAt, track) {


### PR DESCRIPTION
Oops forgot to pull request this
Fixes bug where one variable is wrong and when the timeline component unmounts it throws an error.