### PR TITLE
bug: squashed

### DIFF
--- a/client/store/songs.js
+++ b/client/store/songs.js
@@ -60,7 +60,7 @@ export default function (state = defaultSongs, action) {
     case GET_SONG:
       return [...state, action.song];
     case GET_SOME_SONGS:
-      return [].concat(action.songs, state);
+      return action.songs;
     case REMOVE_SONG:
       return state.filter(song => song.id !== action.song.id);
     case CLEAR_SONGS:

--- a/server/api/songs.js
+++ b/server/api/songs.js
@@ -59,9 +59,9 @@ router.get('/top/:number', (req, res, next) => {
 
 //get a specific song
 router.get('/:id', (req, res, next) => {
-  Song.findById(Number(req.params.id))
+  Song.findOne({ where: { id: Number(req.params.id) }, include: [{ model: User, as: 'artist' }] })
     .then(song => res.json(song))
-    .catch(next)
+    .catch(next);
 })
 
 //to increment play count


### PR DESCRIPTION
fixes bug where switching pages to/from "/song/:id" would break things and you'd have to refresh. We needed eager loading in the api and also to make the reducer discard things sometimes instead of holding on to every song ever loaded